### PR TITLE
test: Add api_client_spec retry on error tests

### DIFF
--- a/spaceship/lib/spaceship/connect_api/api_client.rb
+++ b/spaceship/lib/spaceship/connect_api/api_client.rb
@@ -156,8 +156,8 @@ module Spaceship
         end
       end
 
-      def with_asc_retry(tries = 5, &_block)
-        tries = 1 if Object.const_defined?("SpecHelper")
+      def with_asc_retry(tries = 5, ignore_spec_lock = false, &_block)
+        tries = 1 if Object.const_defined?("SpecHelper") && !ignore_spec_lock
 
         response = yield
 

--- a/spaceship/spec/connect_api/api_client_spec.rb
+++ b/spaceship/spec/connect_api/api_client_spec.rb
@@ -126,6 +126,26 @@ describe Spaceship::ConnectAPI::APIClient do
     end
   end
 
+  describe("retry on error") do
+    let(:mock_token) { double('token') }
+    let(:client) { Spaceship::ConnectAPI::APIClient.new(token: mock_token) }
+    let(:mock_response) { double('response') }
+
+    it 'refreshes token on 401 and does\'t fail after successful retry' do
+      allow(mock_response).to receive(:status).and_return(401)
+      allow(mock_token).to receive(:refresh!)
+
+      call_number = 0
+      client.send(:with_asc_retry, 2, true) do
+        call_number += 1
+        # Fail at first, succeed after all
+        if call_number == 1
+          raise Spaceship::UnauthorizedAccessError
+        end
+      end
+    end
+  end
+
   describe "#handle_error" do
     let(:mock_token) { double('token') }
     let(:client) { Spaceship::ConnectAPI::APIClient.new(token: mock_token) }


### PR DESCRIPTION
Hi.
Thanks for the original PR  [Refresh token and retry on authorization errors](https://github.com/fastlane/fastlane/pull/19502).
I decided to help with tests in case you don't have time for that
